### PR TITLE
Fix typo in JointVelocity controller name.

### DIFF
--- a/perls2/redis_interfaces/redis_keys.py
+++ b/perls2/redis_interfaces/redis_keys.py
@@ -65,7 +65,7 @@ FALSE = "False"
 """
 # Controller types
 JOINT_IMPEDANCE = "JointImpedance"
-JOINT_VELOCITY = "JointVelocty"
+JOINT_VELOCITY = "JointVelocity"
 JOINT_TORQUE = "JointTorque"
 EE_IMPEDANCE = "EEImpedance"
 EE_POSTURE = "EEPosture"

--- a/perls2/redis_interfaces/redis_values.py
+++ b/perls2/redis_interfaces/redis_values.py
@@ -2,7 +2,7 @@
 """
 # Controller types
 JOINT_IMPEDANCE = "JointImpedance"
-JOINT_VELOCITY = "JointVelocty"
+JOINT_VELOCITY = "JointVelocity"
 JOINT_TORQUE = "JointTorque"
 EE_IMPEDANCE = "EEImpedance"
 EE_POSTURE = "EEPosture"


### PR DESCRIPTION
Hi folks - I ran into an error when trying to command a Panda with a joint velocity controller, seems this typo was the issue.